### PR TITLE
Modal Demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-cssmin": "^0.1.6",
     "lodash-node": "^2.4.1",
     "react": "^0.12.2",
+    "react-router": "^0.11.6",
     "reactify": "^0.17.1"
   }
 }

--- a/src/scripts/components/app.js
+++ b/src/scripts/components/app.js
@@ -6,6 +6,7 @@
 
 // ---- External Dependencies ----
 var React = require('react');
+var RouteHandler = require('react-router').RouteHandler;
 var merge = require( '../lib/merge' );
 var debounce = require( 'lodash-node/modern/functions/debounce' );
 
@@ -18,6 +19,7 @@ var PrimaryButtonsDemo = require('./demos/primaryButtons');
 var TextInputsDemo = require('./demos/textInputs');
 var TextAreasDemo = require('./demos/textAreas');
 var FormValidationDemo = require('./demos/formValidation');
+var ModalsDemo = require('./demos/modals');
 
 // ---- Styles ----
 var projectVars = require( '../vars' );
@@ -105,7 +107,9 @@ module.exports = React.createClass( {
           <FormValidationDemo mediaQuery={ this.state.mediaQuery } />
           <StandardButtonsDemo mediaQuery={ this.state.mediaQuery } />
           <PrimaryButtonsDemo mediaQuery={ this.state.mediaQuery } />
+          <ModalsDemo mediaQuery={ this.state.mediaQuery } />
         </div>
+        <RouteHandler mediaQuery={ this.state.mediaQuery } />
       </div>
     );
   }

--- a/src/scripts/components/confetti.js
+++ b/src/scripts/components/confetti.js
@@ -1,0 +1,131 @@
+// ================================================
+// Confetti.js
+// ----
+// Creates "confetti" effect for confirm modal demo
+// ================================================
+
+// ---- External Dependencies ----
+var React = require( 'react' );
+
+// ---- Internal Variables ----
+var COLORS, Confetti, NUM_CONFETTI, PI_2, canvas, confetti, context, drawCircle, i, range, resizeWindow, xpos;
+
+NUM_CONFETTI = 600;
+
+COLORS = [[240, 184, 73], [0, 170, 220], [74, 184, 82]];
+
+PI_2 = 2 * Math.PI;
+
+range = function(a, b) {
+  return (b - a) * Math.random() + a;
+};
+
+xpos = 0.5;
+
+// ---- Styles ----
+var confettiStyles = {
+  canvas: {
+    position: 'absolute',
+    left: '0',
+    width: '100%',
+    height: '100%',
+    opacity: '0.45'
+  }
+};
+
+// ---- React Class ----
+var confettiClass = React.createClass( {
+
+  componentDidMount: function() {
+    canvas = this.getDOMNode();
+    context = canvas.getContext("2d");
+
+    drawCircle = function(x, y, r, style) {
+      context.beginPath();
+      context.arc(x, y, r, 0, PI_2, false);
+      context.fillStyle = style;
+      return context.fill();
+    };
+
+    var w = canvas.width;
+    var h = canvas.height;
+
+    Confetti = (function() {
+      function Confetti() {
+        this.style = COLORS[~~range(0, 3)];
+        this.rgb = "rgba(" + this.style[0] + "," + this.style[1] + "," + this.style[2];
+        this.r = ~~range(2, 4);
+        this.r2 = 2 * this.r;
+        this.replace();
+      }
+
+      Confetti.prototype.replace = function() {
+        this.opacity = 0;
+        this.dop = 0.03 * range(1, 4);
+        this.x = range(-this.r2, w - this.r2);
+        this.y = range(-20, h - this.r2);
+        this.xmax = w - this.r;
+        this.ymax = h - this.r;
+        this.vx = range(0, 2) + 8 * xpos - 5;
+        return this.vy = 0.45 * this.r + range(-1, 1);
+      };
+
+      Confetti.prototype.draw = function() {
+        var _ref;
+        this.x += this.vx;
+        this.y += this.vy;
+        this.opacity += this.dop;
+        if (this.opacity > 1) {
+          this.opacity = 1;
+          this.dop *= -1;
+        }
+        if (this.opacity < 0 || this.y > this.ymax) {
+          this.replace();
+        }
+        if (!((0 < (_ref = this.x) && _ref < this.xmax))) {
+          this.x = (this.x + this.xmax) % this.xmax;
+        }
+        return drawCircle(~~this.x, ~~this.y, this.r, "" + this.rgb + "," + this.opacity + ")");
+      };
+
+      return Confetti;
+
+    })();
+
+    confetti = (function() {
+      var _i, _results;
+      _results = [];
+      for (i = _i = 1; 1 <= NUM_CONFETTI ? _i <= NUM_CONFETTI : _i >= NUM_CONFETTI; i = 1 <= NUM_CONFETTI ? ++_i : --_i) {
+        _results.push(new Confetti);
+      }
+      return _results;
+    })();
+
+    var stepAnimation = function() {
+      var c, _i, _len, _results;
+      requestAnimationFrame( stepAnimation );
+      context.clearRect(0, 0, w, h);
+      _results = [];
+      for (_i = 0, _len = confetti.length; _i < _len; _i++) {
+        c = confetti[_i];
+        _results.push(c.draw());
+      }
+      return _results;
+    };
+
+    stepAnimation();
+  },
+
+  render: function() {
+    return (
+      <canvas style={ confettiStyles.canvas }></canvas>
+    );
+  }
+
+} );
+
+// ==== Module Export ====
+module.exports = {
+  styles: confettiStyles,
+  reactClass: confettiClass
+};

--- a/src/scripts/components/demos/modals.js
+++ b/src/scripts/components/demos/modals.js
@@ -1,0 +1,69 @@
+// ===================================================
+// Modal.js
+// ----
+// Demo section for modals, includes animation example
+// ===================================================
+
+// ---- External Dependencies ----
+var React = require( 'react' );
+var Navigation = require('react-router').Navigation;
+var merge = require( '../../lib/merge' );
+
+// ---- Internal Dependencies ----
+var DemoArea = require('../demoArea');
+var DemoAreaSecHeading = require('../demoAreaSecHeading');
+var DemoAreaFlex = require('../demoAreaFlex');
+var DemoAreaLabel = require('../demoAreaLabel');
+var Button = require( '../button' ).reactClass;
+
+// ---- Styles ----
+var modalStyles = require('../modal').styles;
+var demoHeadingStyles = {
+  marginTop: '14px'
+};
+
+// ---- React Class ----
+module.exports = React.createClass( {
+
+  displayName: 'ModalsDemo',
+
+  mixins: [ Navigation ],
+
+  handleDemoClick: function() {
+    this.transitionTo('/modal');
+  },
+
+  render: function() {
+    var cancelButtonStyles = merge(
+        modalStyles.dialog.paneButton.base,
+        this.props.mediaQuery !== 'small' && modalStyles.mediaQueries.paneButtonMedium,
+        modalStyles.dialog.paneButton.firstChild
+      ),
+      acceptButtonStyles = merge(
+        modalStyles.dialog.paneButton.base,
+        this.props.mediaQuery !== 'small' && modalStyles.mediaQueries.paneButtonMedium,
+        modalStyles.dialog.paneButton.lastChild
+      );
+
+    return (
+      <DemoArea introTitle="Modals" mediaQuery={ this.props.mediaQuery }>
+        <div style={ modalStyles.dialog.base }>
+          <div style={ modalStyles.dialog.topPaneSection }>
+            <h4 style={ modalStyles.dialog.paneHeading }>Header</h4>
+            <p style={ modalStyles.dialog.paneBodyText }>Aliquam nec ultricies purus, eu cursus metus. Donec placerat laoreet vestibulum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi cursus ornare turpis, nec laoreet ipsum tempor id.</p>
+          </div>
+          <div style={ modalStyles.dialog.bottomPaneSection }>
+            <Button style={ cancelButtonStyles } disableEvents={ true }>Cancel</Button>
+            <Button primary={ true } style={ acceptButtonStyles } disableEvents={ true }>Submit</Button>
+          </div>
+        </div>
+        <DemoAreaSecHeading style={ demoHeadingStyles } />
+        <DemoAreaFlex>
+          <DemoAreaLabel demo={ true } mediaQuery={ this.props.mediaQuery }>Demo</DemoAreaLabel>
+          <Button primary={ true } onClick={ this.handleDemoClick }>Show</Button>
+        </DemoAreaFlex>
+      </DemoArea>
+    );
+  }
+
+} );

--- a/src/scripts/components/demos/modals.js
+++ b/src/scripts/components/demos/modals.js
@@ -18,8 +18,13 @@ var Button = require( '../button' ).reactClass;
 
 // ---- Styles ----
 var modalStyles = require('../modal').styles;
-var demoHeadingStyles = {
-  marginTop: '14px'
+var modalDemoStyles = {
+  heading: {
+    marginTop: '14px'
+  },
+  modalDialog: {
+    zIndex: '0'
+  }
 };
 
 // ---- React Class ----
@@ -34,7 +39,11 @@ module.exports = React.createClass( {
   },
 
   render: function() {
-    var cancelButtonStyles = merge(
+    var demoModalDialogStyles = merge(
+        modalStyles.dialog.base,
+        modalDemoStyles.modalDialog
+      ),
+      cancelButtonStyles = merge(
         modalStyles.dialog.paneButton.base,
         this.props.mediaQuery !== 'small' && modalStyles.mediaQueries.paneButtonMedium,
         modalStyles.dialog.paneButton.firstChild
@@ -47,7 +56,7 @@ module.exports = React.createClass( {
 
     return (
       <DemoArea introTitle="Modals" mediaQuery={ this.props.mediaQuery }>
-        <div style={ modalStyles.dialog.base }>
+        <div style={ demoModalDialogStyles }>
           <div style={ modalStyles.dialog.topPaneSection }>
             <h4 style={ modalStyles.dialog.paneHeading }>Header</h4>
             <p style={ modalStyles.dialog.paneBodyText }>Aliquam nec ultricies purus, eu cursus metus. Donec placerat laoreet vestibulum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi cursus ornare turpis, nec laoreet ipsum tempor id.</p>
@@ -57,7 +66,7 @@ module.exports = React.createClass( {
             <Button primary={ true } style={ acceptButtonStyles } disableEvents={ true }>Submit</Button>
           </div>
         </div>
-        <DemoAreaSecHeading style={ demoHeadingStyles } />
+        <DemoAreaSecHeading style={ modalDemoStyles.heading } />
         <DemoAreaFlex>
           <DemoAreaLabel demo={ true } mediaQuery={ this.props.mediaQuery }>Demo</DemoAreaLabel>
           <Button primary={ true } onClick={ this.handleDemoClick }>Show</Button>

--- a/src/scripts/components/modal.js
+++ b/src/scripts/components/modal.js
@@ -1,0 +1,341 @@
+// ===========================================
+// Modal.js
+// ----
+// Demo modal system
+// ===========================================
+
+// ---- External Dependencies ----
+var React = require( 'react' );
+var Navigation = require('react-router').Navigation;
+var merge = require( '../lib/merge' );
+
+// ---- Internal Dependencies ----
+var projectVars = require( '../vars' );
+var Button = require( './button' ).reactClass;
+var ConfettiDemo = require( './confetti' ).reactClass;
+
+// ---- Styles ----
+var typographyStyles = require( './demos/typography' ).styles;
+var modalStyles = {
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'fixed',
+    left: '0',
+    right: '0',
+    top: '0',
+    bottom: '0',
+    perspective: '1000px'
+  },
+  bg: {
+    position: 'absolute',
+    left: '0',
+    right: '0',
+    top: '0',
+    bottom: '0',
+    backgroundColor: 'rgba(200, 215, 225, 0.35)'
+  },
+  dialog: {
+    base: {
+      position: 'relative',
+      zIndex: '2',
+      width: '100%',
+      maxWidth: '472px',
+      border: 'solid 1px #C8D7E1',
+      borderRadius: '4px',
+      backgroundColor: 'white',
+      boxShadow: '0 2px 4px rgba(46, 68, 83, 0.15)',
+      transformStyle: 'preserve-3d'
+    },
+    pane: {
+      backfaceVisibility: 'hidden'
+    },
+    paneBack: {
+      textAlign: 'center'
+    },
+    paneBackText: {
+      heading: {
+        margin: '12px 0 8px'
+      },
+      body: {
+        marginBottom: '12px'
+      }
+    },
+    topPaneSection: {
+      padding: '24px'
+    },
+    bottomPaneSection: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'flee-start',
+      padding: '16px 24px',
+      borderTop: 'solid 1px #F3F6F8'
+    },
+    paneHeading: {
+      marginBottom: '12px',
+      fontSize: '21px',
+      fontWeight: '300',
+      lineHeight: '24px',
+      color: projectVars.colors.textDark
+    },
+    paneBodyText: {
+      fontSize: '14px',
+      lineHeight: '24px',
+      color: projectVars.colors.textLight
+    },
+    paneButton: {
+      base: {
+        flex: '1 0 auto'
+      },
+      firstChild: {
+        marginRight: '4px'
+      },
+      lastChild: {
+        marginLeft: '4px'
+      }
+    }
+  },
+  mediaQueries: {
+    paneButtonMedium: {
+      flex: 'none'
+    }
+  }
+};
+
+// ---- React Class ----
+var modalClass = React.createClass( {
+
+  displayName: 'Modal',
+
+  mixins: [ Navigation ],
+
+  statics: {
+    willTransitionFrom: function(transition, component) {
+      if ( component.state.modalIn || component.state.transitioning ) {
+        transition.abort();
+
+        if ( component.state.modalIn ) {
+          component.playAnimationCancel();
+        } else if ( component.state.transitioning ) {
+          component.animInPlayer.reverse();
+        }
+
+        component.animInPlayer.onfinish = function() {
+          component.setState( {
+            transitioning: false,
+            modalIn: false
+          } );
+
+          transition.retry();
+        };
+      }
+    }
+  },
+
+  getInitialState: function() {
+    return {
+      accepted: false
+    };
+  },
+
+  componentWillMount: function() {
+    this.setState( {
+      transitioning: true,
+      modalIn: false
+    } );
+  },
+
+  componentDidMount: function() {
+    this.playAnimationIn();
+  },
+
+  componentDidUpdate: function( prevProps, prevState ) {
+    if ( this.state.accepted && ! prevState.accepted ) {
+      this.playAnimationAccept();
+    }
+  },
+
+  playAnimationIn: function() {
+    this.refs.bg.getDOMNode().animate(
+      [
+        { opacity: '0' },
+        { opacity: '1' }
+      ], {
+        duration: 300,
+        easing: 'ease-in-out',
+        fill: 'both'
+      }
+    );
+
+    this.animInPlayer = this.refs.dialog.getDOMNode().animate(
+      [
+        { transform: 'scale(0.3) rotateX(-90deg) translate3d(0, 60px, 0)', opacity: '0' },
+        { transform: 'translate3d(0, 0, 0)', opacity: '1' }
+      ],
+      {
+        duration: 400,
+        delay: 200,
+        easing: 'cubic-bezier(0.175, 0.885, 0.320, 1.275)',
+        fill: 'both'
+      }
+    );
+
+    this.animInPlayer.onfinish = function() {
+      this.setState( {
+        transitioning: false,
+        modalIn: true
+      } );
+    }.bind( this );
+  },
+
+  playAnimationCancel: function() {
+    if ( this.state.accepted ) {
+      var animOut = new AnimationGroup( [
+        new Animation (
+          this.refs.bg.getDOMNode(), [
+            { opacity: '1' },
+            { opacity: '0' }
+          ], {
+            duration: 600,
+            delay: 200,
+            fill: 'both'
+          }
+        ),
+        new Animation (
+          this.refs.confetti.getDOMNode(), [
+            { opacity: '1' },
+            { opacity: '0' }
+          ], {
+            duration: 800,
+            fill: 'both'
+          }
+        ),
+        new Animation (
+          this.refs.dialog.getDOMNode(), [
+            { transform: 'translate3d(0, 0, 0)', opacity: '1' },
+            { transform: 'scale(0.3) rotateX(90deg) translate3d(0, -540px, 0)', opacity: '0' }
+          ], {
+            duration: 400,
+            easing: 'cubic-bezier(0.600, -0.280, 0.735, 0.045)',
+            fill: 'both'
+          }
+        )
+      ] );
+    } else {
+      var animOut = new AnimationGroup( [
+        new Animation (
+          this.refs.bg.getDOMNode(), [
+            { opacity: '1' },
+            { opacity: '0' }
+          ], {
+            duration: 600,
+            delay: 200,
+            fill: 'both'
+          }
+        ),
+        new Animation (
+          this.refs.dialog.getDOMNode(), [
+            { transform: 'translate3d(0, 0, 0)', opacity: '1' },
+            { transform: 'scale(0.3) rotateX(90deg) translate3d(0, -540px, 0)', opacity: '0' }
+          ], {
+            duration: 400,
+            easing: 'cubic-bezier(0.600, -0.280, 0.735, 0.045)',
+            fill: 'both'
+          }
+        )
+      ] );
+    }
+
+    this.animInPlayer = document.timeline.play( animOut );
+  },
+
+  playAnimationAccept: function() {
+    var animPlayer = this.refs.confetti.getDOMNode().animate(
+      [
+        { opacity: '0' },
+        { opacity: '0.45' }
+      ],
+      {
+        duration: 2600,
+        easing: 'ease',
+        fill: 'both'
+      }
+    );
+
+    animPlayer.onfinish = function() {
+      this.transitionTo('/');
+    }.bind( this );
+  },
+
+  handleBgClick: function() {
+    if ( ! this.state.accepted ) {
+      this.transitionTo('/');
+    }
+  },
+
+  handleCancelClick: function() {
+    this.transitionTo('/');
+  },
+
+  handleAcceptClick: function() {
+    this.setState( {
+      accepted: true
+    } );
+  },
+
+  render: function() {
+    var cancelButtonStyles = merge(
+        modalStyles.dialog.paneButton.base,
+        this.props.mediaQuery !== 'small' && modalStyles.mediaQueries.paneButtonMedium,
+        modalStyles.dialog.paneButton.firstChild
+      ),
+      acceptButtonStyles = merge(
+        modalStyles.dialog.paneButton.base,
+        this.props.mediaQuery !== 'small' && modalStyles.mediaQueries.paneButtonMedium,
+        modalStyles.dialog.paneButton.lastChild
+      );
+
+    if ( this.state.accepted ) {
+      return (
+        <div style={ modalStyles.base }>
+          <div ref="bg" style={ modalStyles.bg }></div>
+          <div ref="dialog" style={ modalStyles.dialog.base }>
+            <div style={ merge( modalStyles.dialog.pane, modalStyles.dialog.paneBack ) }>
+              <div style={ modalStyles.dialog.topPaneSection }>
+                <h2 style={ merge( typographyStyles.managePostTitle, modalStyles.dialog.paneBackText.heading ) }>Congratulations!</h2>
+                <p style={ merge( typographyStyles.caption, modalStyles.dialog.paneBackText.body ) }>Your credit card has been successfully charged $400</p>
+              </div>
+            </div>
+          </div>
+          <ConfettiDemo ref="confetti" />
+        </div>
+      );
+    } else {
+      return (
+        <div style={ modalStyles.base }>
+          <div ref="bg" style={ modalStyles.bg } onClick={ this.handleBgClick }></div>
+          <div ref="dialog" style={ modalStyles.dialog.base }>
+            <div style={ modalStyles.dialog.pane }>
+              <div style={ modalStyles.dialog.topPaneSection }>
+                <h4 style={ modalStyles.dialog.paneHeading }>Terms of Service</h4>
+                <p style={ modalStyles.dialog.paneBodyText }>You are responsible for any clicks clicks made on the buttons present in this modal and for any consequences thereof.</p>
+              </div>
+              <div style={ modalStyles.dialog.bottomPaneSection }>
+                <Button style={ cancelButtonStyles } onClick={ this.handleCancelClick }>Cancel</Button>
+                <Button primary={ true } style={ acceptButtonStyles } onClick={ this.handleAcceptClick }>Accept</Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  }
+
+} );
+
+// ==== Module Export ====
+module.exports = {
+  styles: modalStyles,
+  reactClass: modalClass
+};

--- a/src/scripts/components/textInput.js
+++ b/src/scripts/components/textInput.js
@@ -101,7 +101,8 @@ var inputClass = React.createClass( {
       ( this.state.hover || this.props.hover ) && inputStyles.hover,
       ( this.state.focus || this.props.focus ) && inputStyles.focus,
       this.props.disabled && inputStyles.disabled,
-      ( this.state.error || this.props.error ) && inputStyles.error
+      ( this.state.error || this.props.error ) && inputStyles.error,
+      this.props.style
     );
     var renderedContainerStyles = merge(
       demoContainerStyles.base,

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,4 +1,16 @@
-var APP = require('./components/app');
 var React = require('react');
+var Router = require('react-router');
+var Route = Router.Route;
 
-React.render( <APP />, document.getElementById('main') );
+var App = require('./components/app');
+var Modal = require('./components/modal').reactClass;
+
+var routes = (
+  <Route name="app" path="/" handler={App} ignoreScrollBehavior={ true }>
+    <Route name="modal" handler={Modal} ignoreScrollBehavior={ true } />
+  </Route>
+);
+
+Router.run(routes, function(Handler) {
+  React.render(<Handler />, document.getElementById('main'));
+});


### PR DESCRIPTION
Adds modal demo section that attempts two techniques:
#### Router Controlled Animations

The modal demo actually responds to a URL change rather than a direct click. Attaching the animation playback to route shifts allows for the user to:
- Navigate directly to that page and still have animation play correctly.
- Utilize standard browser controls (back/forward buttons) that the animation will respond to correctly.
#### Keeping React Lifecycle Methods

Usually, when attempting animations in React (especially the outro), it's fairly difficult to still utilize the built in [lifecycle methods](http://facebook.github.io/react/docs/component-specs.html). This PR tries it's best to still utilize those methods in place and not keep the elements in the DOM pre/post animation.

---

![modal_animation](https://cloud.githubusercontent.com/assets/1427136/6215373/ee47e322-b5cd-11e4-94a4-3a1a708d4dc2.gif)
